### PR TITLE
Fix prefix in query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 /dist/
 /docs/build/
+/.nox/

--- a/src/rdfox_runner/rdfox_endpoint.py
+++ b/src/rdfox_runner/rdfox_endpoint.py
@@ -116,12 +116,14 @@ class RDFoxEndpoint:
         :raises: ParsingError
         """
 
+        # FIXME this should be handled by configuring RDFox directly?
+        query_prefixes = "\n".join([
+            f"PREFIX {k}: <{v}>"
+            for k, v in self.namespaces.items()
+        ])
+
         params = {
-            "query": query,
-            "prefix": [
-                f"{k}: <{v}>"
-                for k, v in self.namespaces.items()
-            ]
+            "query": query_prefixes + query,
         }
 
         headers = {}

--- a/tests/test_rdfox_api.py
+++ b/tests/test_rdfox_api.py
@@ -37,9 +37,11 @@ def w3c_script(port):
         'endpoint start',
     ]
 
-# Namespaces available in queries
+# Namespaces available in queries -- include more than 1 to test a bug with
+# defining multiple namespaces.
 W3C_NAMESPACES = {
     "foaf": FOAF,
+    "foaf-again": FOAF,
 }
 
 

--- a/tests/test_rdfox_api.py
+++ b/tests/test_rdfox_api.py
@@ -41,7 +41,7 @@ def w3c_script(port):
 # defining multiple namespaces.
 W3C_NAMESPACES = {
     "foaf": FOAF,
-    "foaf-again": FOAF,
+    "another": "http://example.org/",
 }
 
 


### PR DESCRIPTION
Defining prefixes using HTTP query arguments hasn't been supported since RDFox v6

For backwards compatibility, `RDFoxEndpoint` now adds any defined namespaces to the start of queries using `query_raw`.

In future, it might be best to configure prefixes within RDFox directly?